### PR TITLE
Add Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ let provider = ServiceCollection::new()
 
 _Figure 2: Using scoped services_
 
+>Note: `scoped` and `transient` are utility functions provided by the **builder** feature.
+
 ### Validation
 
 The consumers of a `ServiceProvider` expect that is correctly configured and ready for use. There are edge cases,
@@ -157,11 +159,11 @@ however, which could lead to runtime failures.
 - A required, dependent service that has not be registered
 - A circular dependency, which will trigger a stack overflow
 
-Intrinsic validation has been added to ensure this cannot happen. The `build_provider()` method will return
+Intrinsic validation has been added to ensure this cannot happen. The `build_provider()` function will return
 `Result<ServiceProvider, ValidationError>`, which will either contain a valid `ServiceProvider` or a
 `ValidationError` that will detail all of the errors. From that point forward, the `ServiceProvider` will be
 considered semantically correct and safe to use. The same validation process can also be invoked imperatively
-on-demand by using the `di::validate` method.
+on-demand by using the `di::validate` function.
 
 The `ServiceDescriptorBuilder` cannot automatically determine the dependencies your service may require. This
 means that validation is an explicit, opt-in capability. If you do not configure any dependencies for a
@@ -191,6 +193,8 @@ fn main() {
 }
 ```
 _Figure 3: Validating service configuration_
+
+>Note: `singleton`, `transient`, and `exactly_one` are utility functions provided by the **builder** feature.
 
 ### Inject Feature
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ fn main() {
         .from(|_| Rc::new(FooImpl::default())));
     services.add(
         transient::<dyn Bar, BarImpl>()
-        .depends_on(ServiceDependency::new(Type::of::<dyn Foo>(), ServiceMultiplicity::ExactlyOne))
+        .depends_on(exactly_one::<dyn Foo>())
         .from(|sp| Rc::new(BarImpl::new(sp.get_required::<dyn Foo>()))));
 
     match services.build_provider() {
@@ -301,9 +301,9 @@ Which will expand to:
 impl Injectable for BarImpl {
     fn inject(lifetime: ServiceLifetime) -> ServiceDescriptor {
         ServiceDescriptorBuilder::<dyn Bar, Self>::new(lifetime, Type::of::<Self>())
-            .depends_on(ServiceDependency::new(Type::of::<dyn Foo>(), ServiceMultiplicity::ExactlyOne))
-            .depends_on(ServiceDependency::new(Type::of::<dyn Translator>(), ServiceMultiplicity::ZeroOrOne))
-            .depends_on(ServiceDependency::new(Type::of::<dyn Logger>(), ServiceMultiplicity::ZeroOrMore))
+            .depends_on(ServiceDependency::new(Type::of::<dyn Foo>(), ServiceCardinality::ExactlyOne))
+            .depends_on(ServiceDependency::new(Type::of::<dyn Translator>(), ServiceCardinality::ZeroOrOne))
+            .depends_on(ServiceDependency::new(Type::of::<dyn Logger>(), ServiceCardinality::ZeroOrMore))
             .from(|sp| Rc::new(
                 BarImpl::create(
                     sp.get_required::<dyn Foo>(),

--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-di"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2018"
 authors = ["Chris Martinez <chris_martinez_77@hotmail.com>"]
 description = "Provides support for dependency injection (DI)"
@@ -23,7 +23,7 @@ inject = ["more-di-macros"]
 
 [dependencies.more-di-macros]
 path = "../di_macros"
-version = "1.0"
+version = "2.0"
 optional = true
 
 [dependencies.spin]

--- a/src/di/builder.rs
+++ b/src/di/builder.rs
@@ -124,3 +124,21 @@ pub fn existing_as_self<T: Any>(instance: T) -> ServiceDescriptor {
         ServiceRef::new(no_op),
     )
 }
+
+/// Creates a new service dependency with a cardinality of exactly one (1:1).
+#[inline]
+pub fn exactly_one<T: Any + ?Sized>() -> ServiceDependency {
+    ServiceDependency::new(Type::of::<T>(), ServiceCardinality::ExactlyOne)
+}
+
+/// Creates a new service dependency with a cardinality of zero or one (0:1).
+#[inline]
+pub fn zero_or_one<T: Any + ?Sized>() -> ServiceDependency {
+    ServiceDependency::new(Type::of::<T>(), ServiceCardinality::ZeroOrOne)
+}
+
+/// Creates a new service dependency with a cardinality of zero or more (0:*).
+#[inline]
+pub fn zero_or_more<T: Any + ?Sized>() -> ServiceDependency {
+    ServiceDependency::new(Type::of::<T>(), ServiceCardinality::ZeroOrMore)
+}

--- a/src/di/dependency.rs
+++ b/src/di/dependency.rs
@@ -1,23 +1,23 @@
 use crate::Type;
 
-/// Represents the possible multiplicities of a service dependency.
+/// Represents the possible cardinalities of a service dependency.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ServiceMultiplicity {
-    /// Indicates a multiplicity of zero or one (0:1).
+pub enum ServiceCardinality {
+    /// Indicates a cardinality of zero or one (0:1).
     ZeroOrOne,
 
-    /// Indicates a multiplicity of exactly one (1:1).
+    /// Indicates a cardinality of exactly one (1:1).
     ExactlyOne,
 
-    /// Indicates a multiplicity of zero or more (0:*).
+    /// Indicates a cardinality of zero or more (0:*).
     ZeroOrMore,
 }
 
 /// Represents a service dependency.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ServiceDependency {
     injected_type: Type,
-    multiplicity: ServiceMultiplicity,
+    cardinality: ServiceCardinality,
 }
 
 impl ServiceDependency {
@@ -26,11 +26,11 @@ impl ServiceDependency {
     /// # Arguments
     /// 
     /// * `injected_type` - the [injected type](struct.Type.html) of the service dependency
-    /// * `multiplicity` - the [multiplicity](enum.ServiceMultiplicity.html) of the service dependency
-    pub fn new(injected_type: Type, multiplicity: ServiceMultiplicity) -> Self {
+    /// * `cardinality` - the [cardinality](enum.ServiceCardinality.html) of the service dependency
+    pub fn new(injected_type: Type, cardinality: ServiceCardinality) -> Self {
         Self {
             injected_type,
-            multiplicity,
+            cardinality,
         }
     }
 
@@ -39,8 +39,8 @@ impl ServiceDependency {
         &self.injected_type
     }
 
-    /// Gets the [multiplicity](enum.ServiceMultiplicity.html) associated with the service dependency.
-    pub fn multiplicity(&self) -> ServiceMultiplicity {
-        self.multiplicity
+    /// Gets the [cardinality](enum.ServiceCardinality.html) associated with the service dependency.
+    pub fn cardinality(&self) -> ServiceCardinality {
+        self.cardinality
     }
 }

--- a/src/di/dependency.rs
+++ b/src/di/dependency.rs
@@ -1,0 +1,46 @@
+use crate::Type;
+
+/// Represents the possible multiplicities of a service dependency.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ServiceMultiplicity {
+    /// Indicates a multiplicity of zero or one (0:1).
+    ZeroOrOne,
+
+    /// Indicates a multiplicity of exactly one (1:1).
+    ExactlyOne,
+
+    /// Indicates a multiplicity of zero or more (0:*).
+    ZeroOrMore,
+}
+
+/// Represents a service dependency.
+#[derive(Clone)]
+pub struct ServiceDependency {
+    injected_type: Type,
+    multiplicity: ServiceMultiplicity,
+}
+
+impl ServiceDependency {
+    /// Initializes a new service dependency.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `injected_type` - the [injected type](struct.Type.html) of the service dependency
+    /// * `multiplicity` - the [multiplicity](enum.ServiceMultiplicity.html) of the service dependency
+    pub fn new(injected_type: Type, multiplicity: ServiceMultiplicity) -> Self {
+        Self {
+            injected_type,
+            multiplicity,
+        }
+    }
+
+    /// Gets the [injected type](struct.Type.html) associated with the service dependency.
+    pub fn injected_type(&self) -> &Type {
+        &self.injected_type
+    }
+
+    /// Gets the [multiplicity](enum.ServiceMultiplicity.html) associated with the service dependency.
+    pub fn multiplicity(&self) -> ServiceMultiplicity {
+        self.multiplicity
+    }
+}

--- a/src/di/inject.rs
+++ b/src/di/inject.rs
@@ -72,7 +72,8 @@ mod tests {
         let services = ServiceCollection::new()
             .add(TestServiceImpl::singleton())
             .add(OtherTestServiceImpl::transient())
-            .build_provider();
+            .build_provider()
+            .unwrap();
 
         // act
         let service = services.get::<dyn OtherTestService>();

--- a/src/di/lib.rs
+++ b/src/di/lib.rs
@@ -2,8 +2,10 @@
 
 mod r#type;
 mod collection;
+mod dependency;
 mod descriptor;
 mod provider;
+mod validation;
 
 #[cfg(feature = "builder")]
 mod builder;
@@ -16,8 +18,10 @@ mod test;
 
 pub use r#type::*;
 pub use collection::*;
+pub use dependency::*;
 pub use descriptor::*;
 pub use provider::*;
+pub use validation::*;
 
 #[cfg(feature = "builder")]
 pub use builder::*;

--- a/src/di/provider.rs
+++ b/src/di/provider.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn get_should_return_none_when_service_is_unregistered() {
         // arrange
-        let services = ServiceCollection::new().build_provider();
+        let services = ServiceCollection::new().build_provider().unwrap();
 
         // act
         let result = services.get::<dyn TestService>();
@@ -161,7 +161,8 @@ mod tests {
                 singleton::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
 
         // act
         let result = services.get::<dyn TestService>();
@@ -178,7 +179,8 @@ mod tests {
                 singleton::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
 
         // act
         let _ = services.get_required::<dyn TestService>();
@@ -193,7 +195,7 @@ mod tests {
     )]
     fn get_required_should_panic_when_service_is_unregistered() {
         // arrange
-        let services = ServiceCollection::new().build_provider();
+        let services = ServiceCollection::new().build_provider().unwrap();
 
         // act
         let _ = services.get_required::<dyn TestService>();
@@ -217,7 +219,8 @@ mod tests {
                     ))
                 }),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
 
         // act
         let svc2 = services.get_required::<dyn OtherTestService>();
@@ -236,7 +239,8 @@ mod tests {
                 transient::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
 
         // act
         let svc1 = services.get_required::<dyn TestService>();
@@ -261,7 +265,7 @@ mod tests {
                     .from(|_| ServiceRef::new(TestService2Impl { value: 2 })),
             );
 
-        let provider = collection.build_provider();
+        let provider = collection.build_provider().unwrap();
 
         // act
         let services = provider.get_all::<dyn TestService>();
@@ -280,7 +284,8 @@ mod tests {
                 scoped::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
         let scope1 = services.create_scope();
         let scope2 = services.create_scope();
 
@@ -301,7 +306,8 @@ mod tests {
                 scoped::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
         let scope1 = services.create_scope();
         let scope2 = scope1.create_scope();
 
@@ -322,7 +328,8 @@ mod tests {
                 singleton::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
         let svc1 = services.get_required::<dyn TestService>();
         let scope1 = services.create_scope();
         let scope2 = scope1.create_scope();
@@ -345,7 +352,8 @@ mod tests {
                 singleton::<dyn TestService, TestServiceImpl>()
                     .from(|_| ServiceRef::new(TestServiceImpl::default())),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
         let scope1 = services.create_scope();
         let scope2 = scope1.create_scope();
         let svc1 = services.get_required::<dyn TestService>();
@@ -368,7 +376,7 @@ mod tests {
         {
             let mut services = ServiceCollection::new();
             services.add(existing_as_self(Droppable::new(file.clone())));
-            let _ = services.build_provider();
+            let _ = services.build_provider().unwrap();
         }
 
         // assert
@@ -389,7 +397,8 @@ mod tests {
                 .add(singleton_as_self().from(|sp| {
                     ServiceRef::new(Droppable::new(sp.get_required::<Path>().to_path_buf()))
                 }))
-                .build_provider();
+                .build_provider()
+                .unwrap();
             let _ = provider.get_required::<Droppable>();
         }
 
@@ -411,7 +420,8 @@ mod tests {
                 .add(singleton_as_self().from(|sp| {
                     ServiceRef::new(Droppable::new(sp.get_required::<Path>().to_path_buf()))
                 }))
-                .build_provider();
+                .build_provider()
+                .unwrap();
         }
 
         // assert
@@ -435,11 +445,12 @@ mod tests {
         // arrange
         let provider = ServiceCollection::new()
             .add(
-                singleton::<dyn TestService, TestAsyncServiceImpl>().from(|_sp| {
+                singleton::<dyn TestService, TestAsyncServiceImpl>().from(|_| {
                     ServiceRef::new(TestAsyncServiceImpl::default())
                 }),
             )
-            .build_provider();
+            .build_provider()
+            .unwrap();
         let holder = inject(provider);
         let h1 = holder.clone();
         let h2 = holder.clone();

--- a/src/di/test.rs
+++ b/src/di/test.rs
@@ -20,6 +20,8 @@ pub(crate) trait TestService {
 
 pub(crate) trait OtherTestService {}
 
+pub(crate) trait AnotherTestService {}
+
 #[derive(Default)]
 pub(crate) struct TestServiceImpl {
     pub value: usize,
@@ -82,5 +84,56 @@ impl TestService for TestAsyncServiceImpl {
         let mut value = self.value.lock().unwrap();
         *value += 1;
         *value
+    }
+}
+
+pub(crate) struct TestOptionalDepImpl {
+    _service: Option<ServiceRef<dyn TestService>>,
+}
+
+impl TestOptionalDepImpl {
+    pub fn new(service: Option<ServiceRef<dyn TestService>>) -> Self {
+        Self { _service: service }
+    }
+}
+
+impl OtherTestService for TestOptionalDepImpl {}
+
+pub(crate) struct TestCircularDepImpl {
+    _service: ServiceRef<dyn TestService>,
+}
+
+impl TestCircularDepImpl {
+    pub fn new(service: ServiceRef<dyn TestService>) -> Self {
+        Self { _service: service }
+    }
+}
+
+impl TestService for TestCircularDepImpl {
+    fn value(&self) -> usize {
+        42
+    }
+}
+
+pub(crate) struct TestAllKindOfProblems {
+    _other: ServiceRef<dyn OtherTestService>,
+    _another: ServiceRef<dyn AnotherTestService>,
+}
+
+impl TestAllKindOfProblems {
+    pub fn new(
+        other: ServiceRef<dyn OtherTestService>,
+        another: ServiceRef<dyn AnotherTestService>,
+    ) -> Self {
+        Self {
+            _other: other,
+            _another: another,
+        }
+    }
+}
+
+impl TestService for TestAllKindOfProblems {
+    fn value(&self) -> usize {
+        42
     }
 }

--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -1,4 +1,4 @@
-use crate::{ServiceCollection, ServiceDependency, ServiceDescriptor, ServiceCardinality, Type};
+use crate::{ServiceCardinality, ServiceCollection, ServiceDependency, ServiceDescriptor, Type};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -185,10 +185,7 @@ mod tests {
 
         services.add(
             singleton::<dyn OtherTestService, OtherTestServiceImpl>()
-                .depends_on(ServiceDependency::new(
-                    Type::of::<dyn TestService>(),
-                    ServiceCardinality::ExactlyOne,
-                ))
+                .depends_on(exactly_one::<dyn TestService>())
                 .from(|sp| {
                     ServiceRef::new(OtherTestServiceImpl::new(
                         sp.get_required::<dyn TestService>(),
@@ -212,10 +209,7 @@ mod tests {
 
         services.add(
             singleton::<dyn OtherTestService, TestOptionalDepImpl>()
-                .depends_on(ServiceDependency::new(
-                    Type::of::<dyn TestService>(),
-                    ServiceCardinality::ZeroOrOne,
-                ))
+                .depends_on(zero_or_one::<dyn TestService>())
                 .from(|sp| ServiceRef::new(TestOptionalDepImpl::new(sp.get::<dyn TestService>()))),
         );
 
@@ -233,10 +227,7 @@ mod tests {
 
         services.add(
             singleton::<dyn TestService, TestCircularDepImpl>()
-                .depends_on(ServiceDependency::new(
-                    Type::of::<dyn TestService>(),
-                    ServiceCardinality::ExactlyOne,
-                ))
+                .depends_on(exactly_one::<dyn TestService>())
                 .from(|sp| {
                     ServiceRef::new(TestCircularDepImpl::new(
                         sp.get_required::<dyn TestService>(),
@@ -261,14 +252,8 @@ mod tests {
         services
             .add(
                 singleton::<dyn TestService, TestAllKindOfProblems>()
-                    .depends_on(ServiceDependency::new(
-                        Type::of::<dyn OtherTestService>(),
-                        ServiceCardinality::ExactlyOne,
-                    ))
-                    .depends_on(ServiceDependency::new(
-                        Type::of::<dyn AnotherTestService>(),
-                        ServiceCardinality::ExactlyOne,
-                    ))
+                    .depends_on(exactly_one::<dyn OtherTestService>())
+                    .depends_on(exactly_one::<dyn AnotherTestService>())
                     .from(|sp| {
                         ServiceRef::new(TestAllKindOfProblems::new(
                             sp.get_required::<dyn OtherTestService>(),
@@ -278,10 +263,7 @@ mod tests {
             )
             .add(
                 singleton::<dyn OtherTestService, OtherTestServiceImpl>()
-                    .depends_on(ServiceDependency::new(
-                        Type::of::<dyn TestService>(),
-                        ServiceCardinality::ExactlyOne,
-                    ))
+                    .depends_on(exactly_one::<dyn TestService>())
                     .from(|sp| {
                         ServiceRef::new(OtherTestServiceImpl::new(
                             sp.get_required::<dyn TestService>(),

--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -1,4 +1,4 @@
-use crate::{ServiceCollection, ServiceDependency, ServiceDescriptor, ServiceMultiplicity, Type};
+use crate::{ServiceCollection, ServiceDependency, ServiceDescriptor, ServiceCardinality, Type};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -75,7 +75,7 @@ impl<'a> MissingRequiredType<'a> {
 impl<'a> ValidationRule<'a> for MissingRequiredType<'a> {
     fn evaluate(&self, descriptor: &'a ServiceDescriptor, results: &mut Vec<ValidationResult>) {
         for dependency in descriptor.dependencies() {
-            if dependency.multiplicity() == ServiceMultiplicity::ExactlyOne
+            if dependency.cardinality() == ServiceCardinality::ExactlyOne
                 && !self.lookup.contains_key(dependency.injected_type())
             {
                 results.push(ValidationResult::fail(format!(
@@ -187,7 +187,7 @@ mod tests {
             singleton::<dyn OtherTestService, OtherTestServiceImpl>()
                 .depends_on(ServiceDependency::new(
                     Type::of::<dyn TestService>(),
-                    ServiceMultiplicity::ExactlyOne,
+                    ServiceCardinality::ExactlyOne,
                 ))
                 .from(|sp| {
                     ServiceRef::new(OtherTestServiceImpl::new(
@@ -214,7 +214,7 @@ mod tests {
             singleton::<dyn OtherTestService, TestOptionalDepImpl>()
                 .depends_on(ServiceDependency::new(
                     Type::of::<dyn TestService>(),
-                    ServiceMultiplicity::ZeroOrOne,
+                    ServiceCardinality::ZeroOrOne,
                 ))
                 .from(|sp| ServiceRef::new(TestOptionalDepImpl::new(sp.get::<dyn TestService>()))),
         );
@@ -235,7 +235,7 @@ mod tests {
             singleton::<dyn TestService, TestCircularDepImpl>()
                 .depends_on(ServiceDependency::new(
                     Type::of::<dyn TestService>(),
-                    ServiceMultiplicity::ExactlyOne,
+                    ServiceCardinality::ExactlyOne,
                 ))
                 .from(|sp| {
                     ServiceRef::new(TestCircularDepImpl::new(
@@ -263,11 +263,11 @@ mod tests {
                 singleton::<dyn TestService, TestAllKindOfProblems>()
                     .depends_on(ServiceDependency::new(
                         Type::of::<dyn OtherTestService>(),
-                        ServiceMultiplicity::ExactlyOne,
+                        ServiceCardinality::ExactlyOne,
                     ))
                     .depends_on(ServiceDependency::new(
                         Type::of::<dyn AnotherTestService>(),
-                        ServiceMultiplicity::ExactlyOne,
+                        ServiceCardinality::ExactlyOne,
                     ))
                     .from(|sp| {
                         ServiceRef::new(TestAllKindOfProblems::new(
@@ -280,7 +280,7 @@ mod tests {
                 singleton::<dyn OtherTestService, OtherTestServiceImpl>()
                     .depends_on(ServiceDependency::new(
                         Type::of::<dyn TestService>(),
-                        ServiceMultiplicity::ExactlyOne,
+                        ServiceCardinality::ExactlyOne,
                     ))
                     .from(|sp| {
                         ServiceRef::new(OtherTestServiceImpl::new(

--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -1,0 +1,303 @@
+use crate::{ServiceCollection, ServiceDependency, ServiceDescriptor, ServiceMultiplicity, Type};
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Debug)]
+struct ValidationResult {
+    message: String,
+}
+
+impl ValidationResult {
+    fn fail<T: AsRef<str>>(message: T) -> Self {
+        Self {
+            message: String::from(message.as_ref()),
+        }
+    }
+}
+
+/// Represents an validation error.
+#[derive(Clone, Debug)]
+pub struct ValidationError {
+    message: String,
+    results: Vec<ValidationResult>,
+}
+
+impl ValidationError {
+    fn fail(results: Vec<ValidationResult>) -> Self {
+        Self {
+            message: if results.is_empty() {
+                String::from("Validation failed.")
+            } else if results.len() == 1 {
+                results[0].message.clone()
+            } else {
+                String::from("One or more validation errors occurred.")
+            },
+            results,
+        }
+    }
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), std::fmt::Error> {
+        write!(formatter, "{}", self.message)?;
+
+        if self.results.len() > 1 {
+            for (i, result) in self.results.iter().enumerate() {
+                write!(formatter, "\n  [{}] {}", i + 1, result.message)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for ValidationError {
+    fn description(&self) -> &str {
+        "validation error"
+    }
+}
+
+trait ValidationRule<'a> {
+    fn evaluate(&self, descriptor: &'a ServiceDescriptor, results: &mut Vec<ValidationResult>);
+}
+
+struct MissingRequiredType<'a> {
+    lookup: &'a HashMap<&'a Type, &'a ServiceDescriptor>,
+}
+
+impl<'a> MissingRequiredType<'a> {
+    fn new(lookup: &'a HashMap<&'a Type, &'a ServiceDescriptor>) -> Self {
+        Self { lookup }
+    }
+}
+
+impl<'a> ValidationRule<'a> for MissingRequiredType<'a> {
+    fn evaluate(&self, descriptor: &'a ServiceDescriptor, results: &mut Vec<ValidationResult>) {
+        for dependency in descriptor.dependencies() {
+            if dependency.multiplicity() == ServiceMultiplicity::ExactlyOne
+                && !self.lookup.contains_key(dependency.injected_type())
+            {
+                results.push(ValidationResult::fail(format!(
+                    "Service '{}' requires dependent service '{}', which has not be registered",
+                    descriptor.implementation_type().name(),
+                    dependency.injected_type().name()
+                )));
+            }
+        }
+    }
+}
+
+struct CircularDependency<'a> {
+    lookup: &'a HashMap<&'a Type, &'a ServiceDescriptor>,
+    visited: RefCell<HashSet<&'a Type>>,
+    queue: RefCell<Vec<&'a ServiceDependency>>,
+}
+
+impl<'a> CircularDependency<'a> {
+    fn new(lookup: &'a HashMap<&'a Type, &'a ServiceDescriptor>) -> Self {
+        Self {
+            lookup,
+            visited: RefCell::new(HashSet::new()),
+            queue: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn check_dependency_graph(
+        &self,
+        root: &'a ServiceDescriptor,
+        dependency: &'a ServiceDependency,
+        visited: &mut HashSet<&'a Type>,
+        results: &mut Vec<ValidationResult>,
+    ) {
+        let mut queue = self.queue.borrow_mut();
+
+        queue.clear();
+        queue.push(dependency);
+
+        while let Some(current) = queue.pop() {
+            if let Some(descriptor) = self.lookup.get(current.injected_type()) {
+                if visited.insert(descriptor.service_type()) {
+                    queue.extend(descriptor.dependencies());
+                } else {
+                    results.push(ValidationResult::fail(format!(
+                        "A circular dependency was detected for service '{}' on service '{}'",
+                        descriptor.service_type().name(),
+                        root.implementation_type().name()
+                    )));
+                }
+            }
+        }
+    }
+}
+
+impl<'a> ValidationRule<'a> for CircularDependency<'a> {
+    fn evaluate(&self, descriptor: &'a ServiceDescriptor, results: &mut Vec<ValidationResult>) {
+        let mut visited = self.visited.borrow_mut();
+
+        for dependency in descriptor.dependencies() {
+            visited.clear();
+            visited.insert(descriptor.service_type());
+            self.check_dependency_graph(descriptor, dependency, &mut visited, results);
+        }
+    }
+}
+
+/// Validates the specified [service collection](struct.ServiceCollection.html).
+///
+/// # Arguments
+///
+/// * `services` - The [service collection](struct.ServiceCollection.html) to validate
+pub fn validate(services: &ServiceCollection) -> Result<(), ValidationError> {
+    let mut lookup = HashMap::with_capacity(services.len());
+
+    for i in 0..services.len() {
+        lookup.insert(services[i].service_type(), &services[i]);
+    }
+
+    let mut results = Vec::new();
+    let missing_type = MissingRequiredType::new(&lookup);
+    let circular_dep = CircularDependency::new(&lookup);
+    let rules: Vec<&dyn ValidationRule> = vec![&missing_type, &circular_dep];
+
+    for descriptor in services {
+        for rule in &rules {
+            rule.evaluate(descriptor, &mut results);
+        }
+    }
+
+    if results.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationError::fail(results))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test::*, *};
+
+    #[test]
+    fn validate_should_report_missing_required_type() {
+        // arrange
+        let mut services = ServiceCollection::new();
+
+        services.add(
+            singleton::<dyn OtherTestService, OtherTestServiceImpl>()
+                .depends_on(ServiceDependency::new(
+                    Type::of::<dyn TestService>(),
+                    ServiceMultiplicity::ExactlyOne,
+                ))
+                .from(|sp| {
+                    ServiceRef::new(OtherTestServiceImpl::new(
+                        sp.get_required::<dyn TestService>(),
+                    ))
+                }),
+        );
+
+        // act
+        let result = validate(&services);
+
+        // assert
+        assert_eq!(
+            &result.err().unwrap().to_string(),
+            "Service 'di::test::OtherTestServiceImpl' requires dependent service 'dyn di::test::TestService', which has not be registered");
+    }
+
+    #[test]
+    fn validate_should_ignore_missing_optional_type() {
+        // arrange
+        let mut services = ServiceCollection::new();
+
+        services.add(
+            singleton::<dyn OtherTestService, TestOptionalDepImpl>()
+                .depends_on(ServiceDependency::new(
+                    Type::of::<dyn TestService>(),
+                    ServiceMultiplicity::ZeroOrOne,
+                ))
+                .from(|sp| ServiceRef::new(TestOptionalDepImpl::new(sp.get::<dyn TestService>()))),
+        );
+
+        // act
+        let result = validate(&services);
+
+        // assert
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_should_report_circular_dependency() {
+        // arrange
+        let mut services = ServiceCollection::new();
+
+        services.add(
+            singleton::<dyn TestService, TestCircularDepImpl>()
+                .depends_on(ServiceDependency::new(
+                    Type::of::<dyn TestService>(),
+                    ServiceMultiplicity::ExactlyOne,
+                ))
+                .from(|sp| {
+                    ServiceRef::new(TestCircularDepImpl::new(
+                        sp.get_required::<dyn TestService>(),
+                    ))
+                }),
+        );
+
+        // act
+        let result = validate(&services);
+
+        // assert
+        assert_eq!(
+            &result.err().unwrap().to_string(),
+            "A circular dependency was detected for service 'dyn di::test::TestService' on service 'di::test::TestCircularDepImpl'");
+    }
+
+    #[test]
+    fn validate_should_report_multiple_issues() {
+        // arrange
+        let mut services = ServiceCollection::new();
+
+        services
+            .add(
+                singleton::<dyn TestService, TestAllKindOfProblems>()
+                    .depends_on(ServiceDependency::new(
+                        Type::of::<dyn OtherTestService>(),
+                        ServiceMultiplicity::ExactlyOne,
+                    ))
+                    .depends_on(ServiceDependency::new(
+                        Type::of::<dyn AnotherTestService>(),
+                        ServiceMultiplicity::ExactlyOne,
+                    ))
+                    .from(|sp| {
+                        ServiceRef::new(TestAllKindOfProblems::new(
+                            sp.get_required::<dyn OtherTestService>(),
+                            sp.get_required::<dyn AnotherTestService>(),
+                        ))
+                    }),
+            )
+            .add(
+                singleton::<dyn OtherTestService, OtherTestServiceImpl>()
+                    .depends_on(ServiceDependency::new(
+                        Type::of::<dyn TestService>(),
+                        ServiceMultiplicity::ExactlyOne,
+                    ))
+                    .from(|sp| {
+                        ServiceRef::new(OtherTestServiceImpl::new(
+                            sp.get_required::<dyn TestService>(),
+                        ))
+                    }),
+            );
+
+        // act
+        let result = validate(&services);
+
+        // assert
+        assert_eq!(
+            &result.err().unwrap().to_string(),
+            "One or more validation errors occurred.\n  \
+              [1] Service 'di::test::TestAllKindOfProblems' requires dependent service 'dyn di::test::AnotherTestService', which has not be registered\n  \
+              [2] A circular dependency was detected for service 'dyn di::test::TestService' on service 'di::test::TestAllKindOfProblems'\n  \
+              [3] A circular dependency was detected for service 'dyn di::test::OtherTestService' on service 'di::test::OtherTestServiceImpl'");
+    }
+}

--- a/src/di_macros/Cargo.toml
+++ b/src/di_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-di-macros"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2018"
 authors = ["Chris Martinez <chris_martinez_77@hotmail.com>"]
 description = "Macro implementation of #[injectable(Trait)]"

--- a/src/di_macros/lib.rs
+++ b/src/di_macros/lib.rs
@@ -310,21 +310,21 @@ fn resolve_type(arg: &Type) -> Result<(TokenStream, Option<TokenStream>)> {
                     (
                         quote! { sp.get::<#trait_>() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceMultiplicity::ZeroOrOne) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceCardinality::ZeroOrOne) },
                         ),
                     )
                 } else if many {
                     (
                         quote! { sp.get_all::<#trait_>().collect() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceMultiplicity::ZeroOrMore) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceCardinality::ZeroOrMore) },
                         ),
                     )
                 } else {
                     (
                         quote! { sp.get_required::<#trait_>() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceMultiplicity::ExactlyOne) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#trait_>(), di::ServiceCardinality::ExactlyOne) },
                         ),
                     )
                 }),
@@ -332,21 +332,21 @@ fn resolve_type(arg: &Type) -> Result<(TokenStream, Option<TokenStream>)> {
                     (
                         quote! { sp.get::<#struct_>() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceMultiplicity::ZeroOrOne) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceCardinality::ZeroOrOne) },
                         ),
                     )
                 } else if many {
                     (
                         quote! { sp.get_all::<#struct_>().collect() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceMultiplicity::ZeroOrMore) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceCardinality::ZeroOrMore) },
                         ),
                     )
                 } else {
                     (
                         quote! { sp.get_required::<#struct_>() },
                         Some(
-                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceMultiplicity::ExactlyOne) },
+                            quote! { di::ServiceDependency::new(di::Type::of::<#struct_>(), di::ServiceCardinality::ExactlyOne) },
                         ),
                     )
                 }),
@@ -489,7 +489,7 @@ mod test {
             "impl di :: Injectable for FooImpl { ",
             "fn inject (lifetime : di :: ServiceLifetime) -> di :: ServiceDescriptor { ",
             "di :: ServiceDescriptorBuilder :: < dyn Foo , Self > :: new (lifetime , di :: Type :: of :: < Self > ()) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceMultiplicity :: ExactlyOne)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceCardinality :: ExactlyOne)) ",
             ". from (| sp : & di :: ServiceProvider | di :: ServiceRef :: new (FooImpl :: new (sp . get_required :: < dyn Bar > ()))) ",
             "} ",
             "}");
@@ -525,7 +525,7 @@ mod test {
             "impl di :: Injectable for FooImpl { ",
             "fn inject (lifetime : di :: ServiceLifetime) -> di :: ServiceDescriptor { ",
             "di :: ServiceDescriptorBuilder :: < dyn Foo , Self > :: new (lifetime , di :: Type :: of :: < Self > ()) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceMultiplicity :: ZeroOrOne)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceCardinality :: ZeroOrOne)) ",
             ". from (| sp : & di :: ServiceProvider | di :: ServiceRef :: new (FooImpl :: new (sp . get :: < dyn Bar > ()))) ",
             "} ",
             "}");
@@ -561,7 +561,7 @@ mod test {
             "impl di :: Injectable for FooImpl { ",
             "fn inject (lifetime : di :: ServiceLifetime) -> di :: ServiceDescriptor { ",
             "di :: ServiceDescriptorBuilder :: < dyn Foo , Self > :: new (lifetime , di :: Type :: of :: < Self > ()) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceMultiplicity :: ZeroOrMore)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceCardinality :: ZeroOrMore)) ",
             ". from (| sp : & di :: ServiceProvider | di :: ServiceRef :: new (FooImpl :: new (sp . get_all :: < dyn Bar > () . collect ()))) ",
             "} ",
             "}");
@@ -599,8 +599,8 @@ mod test {
             "impl di :: Injectable for ThingImpl { ",
             "fn inject (lifetime : di :: ServiceLifetime) -> di :: ServiceDescriptor { ",
             "di :: ServiceDescriptorBuilder :: < dyn Thing , Self > :: new (lifetime , di :: Type :: of :: < Self > ()) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Foo > () , di :: ServiceMultiplicity :: ExactlyOne)) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceMultiplicity :: ZeroOrOne)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Foo > () , di :: ServiceCardinality :: ExactlyOne)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < dyn Bar > () , di :: ServiceCardinality :: ZeroOrOne)) ",
             ". from (| sp : & di :: ServiceProvider | di :: ServiceRef :: new (ThingImpl :: create_new (sp . get_required :: < dyn Foo > () , sp . get :: < dyn Bar > ()))) ",
             "} ",
             "}");
@@ -671,7 +671,7 @@ mod test {
             "impl di :: Injectable for FooImpl { ",
             "fn inject (lifetime : di :: ServiceLifetime) -> di :: ServiceDescriptor { ",
             "di :: ServiceDescriptorBuilder :: < dyn Foo , Self > :: new (lifetime , di :: Type :: of :: < Self > ()) ",
-            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < Bar > () , di :: ServiceMultiplicity :: ExactlyOne)) ",
+            ". depends_on (di :: ServiceDependency :: new (di :: Type :: of :: < Bar > () , di :: ServiceCardinality :: ExactlyOne)) ",
             ". from (| sp : & di :: ServiceProvider | di :: ServiceRef :: new (FooImpl :: new (sp . get_required :: < Bar > ()))) ",
             "} ",
             "}");

--- a/test/di/Cargo.toml
+++ b/test/di/Cargo.toml
@@ -6,6 +6,8 @@ publish = false
 
 [lib]
 path = "lib.rs"
+doc = false
+doctest = false
 
 [dependencies]
 more-di = { path = "../../src/di" }

--- a/test/di/lib.rs
+++ b/test/di/lib.rs
@@ -1,5 +1,10 @@
 #![cfg(test)]
 
+// since this is a test crate, the test configuration needs to be
+// specified in order to expand macros
+//
+// RUSTFLAGS='--cfg test' cargo expand
+
 mod traits;
 mod structs;
 mod containers;

--- a/test/di/scenarios.rs
+++ b/test/di/scenarios.rs
@@ -102,3 +102,17 @@ fn inject_should_clone_service_provider_and_return_different_scoped_instance() {
     // assert
     assert!(!ServiceRef::ptr_eq(&svc1, &svc2));
 }
+
+#[test]
+fn inject_should_add_dependencies_for_validation() {
+    // arrange
+    let mut services = ServiceCollection::new();
+
+    services.add(traits::FooImpl::transient());
+
+    // act
+    let result = services.build_provider();
+
+    // assert
+    assert!(result.is_err());
+}

--- a/test/di/scenarios.rs
+++ b/test/di/scenarios.rs
@@ -6,7 +6,8 @@ fn inject_should_implement_trait_for_struct() {
     // arrange
     let provider = ServiceCollection::new()
         .add(traits::BarImpl::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
 
     // act
     let bar = provider.get_required::<dyn traits::Bar>();
@@ -21,7 +22,8 @@ fn inject_should_implement_trait_for_struct_with_dependency() {
     let provider = ServiceCollection::new()
         .add(traits::FooImpl::singleton())
         .add(traits::BarImpl::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
 
     // act
     let foo = provider.get_required::<dyn traits::Foo>();
@@ -35,7 +37,8 @@ fn inject_should_implement_struct_for_self() {
     // arrange
     let provider = ServiceCollection::new()
         .add(structs::Bar::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
 
     // act
     let bar = provider.get_required::<structs::Bar>();
@@ -50,7 +53,8 @@ fn inject_should_implement_struct_for_self_with_dependency() {
     let provider = ServiceCollection::new()
         .add(structs::Foo::singleton())
         .add(structs::Bar::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
 
     // act
     let foo = provider.get_required::<structs::Foo>();
@@ -67,7 +71,8 @@ fn inject_should_clone_service_provider_and_return_same_singleton() {
         .add(traits::FooImpl::singleton())
         .add(traits::BarImpl::transient())
         .add(containers::Container::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
     let container = provider.get_required::<containers::Container>();
 
     // act
@@ -86,7 +91,8 @@ fn inject_should_clone_service_provider_and_return_different_scoped_instance() {
         .add(traits::FooImpl::scoped())
         .add(traits::BarImpl::transient())
         .add(containers::ScopedContainer::transient())
-        .build_provider();
+        .build_provider()
+        .unwrap();
     let container = provider.get_required::<containers::ScopedContainer>();
 
     // act


### PR DESCRIPTION
Adds service validation which covers the following main scenarios:

- A missing, required, dependent service
- A circular dependency (which results in stack overflow)

`ServiceCollection::build_provider()` _should_ not allow an invalid `ServiceProvider` to be created. The signature will, therefore, now be:

```rust
pub fn build_provider(&self) -> Result<ServiceProvider, ValidationError>() { }
```

Since that is a breaking change, the crate will also bump to `2.0`.