### PR TITLE
Validate Scoped Service in Singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ _Figure 2: Using scoped services_
 
 ### Validation
 
-The consumers of a `ServiceProvider` expect that is correctly configured and ready for use. There are edge cases,
-however, which could lead to runtime failures.
+The consumers of a `ServiceProvider` expect that it is correctly configured and ready for use. There are edge cases,
+however, which could lead to runtime failures or incorrect behavior such as:
 
 - A required, dependent service that has not be registered
 - A circular dependency, which will trigger a stack overflow
+- A service with a singleton lifetime has a dependent service with a scoped lifetime
 
 Intrinsic validation has been added to ensure this cannot happen. The `build_provider()` function will return
 `Result<ServiceProvider, ValidationError>`, which will either contain a valid `ServiceProvider` or a

--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-di"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2018"
 authors = ["Chris Martinez <chris_martinez_77@hotmail.com>"]
 description = "Provides support for dependency injection (DI)"

--- a/src/di/test.rs
+++ b/src/di/test.rs
@@ -56,6 +56,18 @@ impl OtherTestServiceImpl {
 
 impl OtherTestService for OtherTestServiceImpl {}
 
+pub(crate) struct AnotherTestServiceImpl {
+    _service: ServiceRef<dyn OtherTestService>,
+}
+
+impl AnotherTestServiceImpl {
+    pub fn new(service: ServiceRef<dyn OtherTestService>) -> Self {
+        Self { _service: service }
+    }
+}
+
+impl AnotherTestService for AnotherTestServiceImpl {}
+
 pub(crate) struct Droppable {
     file: PathBuf,
 }


### PR DESCRIPTION
Adds validation to ensure a `Scoped` service cannot be injected into a `Singleton` service