### PR TITLE
fix: preventing false positives when validating circular references. …

### DIFF
--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -120,7 +120,8 @@ impl<'a> CircularDependency<'a> {
 
         while let Some(current) = queue.pop() {
             if let Some(descriptor) = self.lookup.get(current.injected_type()) {
-                if visited.insert(descriptor.service_type()) {
+                if descriptor.service_type() != root.service_type() {
+                    visited.insert(descriptor.service_type());
                     queue.extend(descriptor.dependencies());
                 } else {
                     results.push(ValidationResult::fail(format!(


### PR DESCRIPTION
Thanks for the great job with this awesome DI crate for rust, I tested several DI crates and in my opinion this is the best.

While using the more-rs-di crate I found a false positive error when validating circular dependencies, I checked the issue and I sent a possible solution, it passes the unittests including the one for detecting circular dependencies, in the following text it is an small explanation, but if you have any question I can provide more details and explanation. Thanks a lot!

…This change allows that child dependencies rely on the same dependencies without being a circular reference. example: A, B, C and Z depend on M; A depends on B; Z depends on A and C. This is valid because there are no circular references, however, before this commit this example was interpreted as a circular reference.