### PR TITLE
Add Circular Dependency Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source "$HOME/.cargo/env"
+
+      - name: Install Cargo-to-JUnit
+        run: cargo install cargo2junit
+
+      - name: Cargo Build
+        run: |
+          cargo build
+          cargo build --features async
+
+      - name: Cargo Test
+        run: |
+          cargo test -- -Z unstable-options --format json --report-time | cargo2junit > target/debug/results.xml
+          cargo test --features async -- -Z unstable-options --format json --report-time | cargo2junit > target/debug/results-async.xml
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            target/debug/*.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source "$HOME/.cargo/env"
 
+      # REF: https://crates.io/crates/cargo2junit
+
       - name: Install Cargo-to-JUnit
         run: cargo install cargo2junit
 
@@ -37,6 +39,8 @@ jobs:
         run: |
           cargo test -- -Z unstable-options --format json --report-time | cargo2junit > target/debug/results.xml
           cargo test --features async -- -Z unstable-options --format json --report-time | cargo2junit > target/debug/results-async.xml
+
+      # REF: https://github.com/marketplace/actions/publish-test-results
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
+![CI](https://github.com/commonsensesoftware/more-rs-di/actions/workflows/ci.yml/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/more-di.svg
 [crates-url]: https://crates.io/crates/more-di
-[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-badge]: https://img.shields.io/badge/license-MIT-blueviolet.svg
 [mit-url]: https://github.com/commonsensesoftware/more-rs-di/blob/main/LICENSE
 
 This library contains all of the fundamental abstractions for dependency injection (DI).

--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-di"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2018"
 authors = ["Chris Martinez <chris_martinez_77@hotmail.com>"]
 description = "Provides support for dependency injection (DI)"


### PR DESCRIPTION
- Remove unnecessary type visitation tracking
- Adds a test case for circular dependencies as reported in #7
- Adds a CI workflow for PRs