### PR TITLE
Feature/use graphs to detect circular references

### DIFF
--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -32,6 +32,9 @@ version = "0.9.4"
 default-features = false
 features = ["once"]
 
+[dependencies.daggy]
+version = "0.8.0"
+
 [dev-dependencies.more-di]
 path = "."
 default-features = false

--- a/src/di/test.rs
+++ b/src/di/test.rs
@@ -18,6 +18,20 @@ pub(crate) trait TestService {
     fn value(&self) -> usize;
 }
 
+pub(crate) trait ServiceA {}
+
+pub(crate) trait ServiceB {}
+
+pub(crate) trait ServiceC {}
+
+pub(crate) trait ServiceM {}
+
+pub(crate) trait ServiceY {}
+
+pub(crate) trait ServiceX {}
+
+pub(crate) trait ServiceZ {}
+
 pub(crate) trait OtherTestService {}
 
 pub(crate) trait AnotherTestService {}
@@ -26,6 +40,124 @@ pub(crate) trait AnotherTestService {}
 pub(crate) struct TestServiceImpl {
     pub value: usize,
 }
+
+pub(crate) struct ServiceAImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+    _service_b: ServiceRef<dyn ServiceB>,
+}
+
+impl ServiceAImpl {
+    pub(crate) fn new(
+        _service_m: ServiceRef<dyn ServiceM>,
+        _service_b: ServiceRef<dyn ServiceB>,
+    ) -> Self {
+        Self {
+            _service_m,
+            _service_b,
+        }
+    }
+}
+
+impl ServiceA for ServiceAImpl {}
+
+pub(crate) struct ServiceBImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+}
+
+impl ServiceBImpl {
+    pub(crate) fn new(_service_m: ServiceRef<dyn ServiceM>) -> Self {
+        Self { _service_m }
+    }
+}
+
+impl ServiceB for ServiceBImpl {}
+
+pub(crate) struct ServiceCImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+}
+
+
+impl ServiceCImpl {
+    pub(crate) fn new(_service_m: ServiceRef<dyn ServiceM>) -> Self {
+        Self { _service_m }
+    }
+}
+impl ServiceC for ServiceCImpl {}
+
+pub(crate) struct ServiceCWithCircleRefToXImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+    _service_x: ServiceRef<dyn ServiceX>,
+}
+
+impl ServiceCWithCircleRefToXImpl {
+    pub(crate) fn new(_service_m: ServiceRef<dyn ServiceM>, _service_x: ServiceRef<dyn ServiceX>) -> Self { Self { _service_m, _service_x } }
+}
+
+impl ServiceC for ServiceCWithCircleRefToXImpl {}
+
+pub(crate) struct ServiceMImpl;
+
+impl ServiceM for ServiceMImpl {}
+
+pub(crate) struct ServiceYImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+    _service_c: ServiceRef<dyn ServiceC>,
+}
+
+impl ServiceYImpl {
+    pub(crate) fn new(
+        _service_m: ServiceRef<dyn ServiceM>,
+        _service_c: ServiceRef<dyn ServiceC>,
+    ) -> Self {
+        Self {
+            _service_m,
+            _service_c,
+        }
+    }
+}
+
+impl ServiceY for ServiceYImpl {}
+
+pub(crate) struct ServiceXImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+    _service_y: ServiceRef<dyn ServiceY>,
+}
+
+impl ServiceX for ServiceXImpl {}
+
+impl ServiceXImpl {
+    pub(crate) fn new(
+        _service_m: ServiceRef<dyn ServiceM>,
+        _service_y: ServiceRef<dyn ServiceY>,
+    ) -> Self {
+        Self {
+            _service_m,
+            _service_y,
+        }
+    }
+}
+
+pub(crate) struct ServiceZImpl {
+    _service_m: ServiceRef<dyn ServiceM>,
+    _service_a: ServiceRef<dyn ServiceA>,
+    _service_x: ServiceRef<dyn ServiceX>,
+}
+
+impl ServiceZImpl {
+    pub(crate) fn new(
+        _service_m: ServiceRef<dyn ServiceM>,
+        _service_a: ServiceRef<dyn ServiceA>,
+        _service_x: ServiceRef<dyn ServiceX>,
+    ) -> Self {
+        Self {
+            _service_m,
+            _service_a,
+            _service_x,
+        }
+    }
+}
+
+impl ServiceZ for ServiceZImpl {}
 
 #[derive(Default)]
 pub(crate) struct TestService2Impl {

--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -575,7 +575,7 @@ mod tests {
 
         // act
         let result = validate(&services);
-        assert_eq!(result.is_err(), false) //I will add the proper assert here;
+        assert!(result.is_ok())
     }
 
     #[test]
@@ -650,6 +650,6 @@ mod tests {
 
         // act
         let result = validate(&services);
-        assert_eq!(result.is_err(), true) // I will add the proper assert here;
+        assert!(result.is_err())
     }
 }

--- a/src/di/validation.rs
+++ b/src/di/validation.rs
@@ -129,10 +129,6 @@ impl<'a> CircularDependency<'a> {
                 root.implementation_type().name(),
             ))),
         }
-
-        self.add_nodes(dependency, results);
-
-        results.dedup_by(|a, b| a.message.eq_ignore_ascii_case(&b.message));
     }
 
     fn clean_graph(&self) {


### PR DESCRIPTION
- The dependecies now are represented as nodes and edges in a graph.
- The daggy crate was used construct an acyclic graph.
- Complex circular dependencies unittest were added