### PR TITLE
Update Cargo.toml

### DIFF
--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -28,7 +28,7 @@ version = "2.1"
 optional = true
 
 [dependencies.spin]
-version = "0.9.4"
+version = "0.9.8"
 default-features = false
 features = ["once"]
 


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)