### PR TITLE
Fix feature-gated colored formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
       checks: write
       pull-requests: write
       security-events: write
-    
-    env:
-      CLICOLOR_FORCE: 1
-      COLORTERM: truecolor
-      TERM: xterm-256color
 
     steps:
       - name: Checkout Repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 
 [workspace.dependencies]
 cfg-if = "1.0"
-maybe-impl = "0.1.0"
+maybe-impl = "0.1"

--- a/src/di/Cargo.toml
+++ b/src/di/Cargo.toml
@@ -37,7 +37,7 @@ optional = true
 
 [dependencies]
 cfg-if.workspace = true
-colored = { version = "2.0", optional = true }
+colored = { version = "3.1", optional = true }
 
 [dev-dependencies.more-di]
 path = "."

--- a/src/di/collection.rs
+++ b/src/di/collection.rs
@@ -438,11 +438,15 @@ impl std::fmt::Debug for ServiceCollection {
 
 impl std::fmt::Display for ServiceCollection {
     fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        if f.alternate() && cfg!(feature = "fmt") {
-            fmt::write(self, fmt::terminal::Renderer, f)
-        } else {
-            fmt::write(self, fmt::text::Renderer, f)
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "fmt")] {
+                if f.alternate() {
+                    return fmt::write(self, fmt::terminal::Renderer, f);
+                }
+            }
         }
+
+        fmt::write(self, fmt::text::Renderer, f)
     }
 }
 

--- a/test/di/format.rs
+++ b/test/di/format.rs
@@ -2,6 +2,7 @@
 
 use crate::traits::*;
 use di::*;
+use std::env::set_var;
 
 #[injectable]
 struct A;
@@ -152,6 +153,12 @@ const TEXT_TERMINAL: &str =
  └ [38;2;75;154;214mdyn[0m [38;2;158;211;163mmore_di_tests::traits::Thing[0m → [38;2;78;201;176mmore_di_tests::format::Thing3[0m [38;2;118;118;118m[Scoped][0m\n  \
    └ [38;2;78;201;176mmore_di_tests::format::A[0m → [38;2;78;201;176mmore_di_tests::format::A[0m [38;2;118;118;118m[Singleton][0m\n";
 
+fn force_color_support() {
+    set_var("CLICOLOR_FORCE", "1");
+    set_var("COLORTERM", "truecolor");
+    set_var("TERM", "xterm-256color");
+}
+
 #[test]
 fn debug_should_format_service_collection() {
     // arrange
@@ -180,6 +187,8 @@ fn display_should_format_service_collection() {
 fn alt_display_should_format_service_collection() {
     // arrange
     let services = new_service_collection();
+
+    force_color_support();
 
     // act
     let output = format!("{services:#}");


### PR DESCRIPTION
Fixes colored formatting which is gated behind the **fmt** feature. Colorization if forced by environment variables so detection works on all platforms during the integration tests.